### PR TITLE
Upgrade hadoop-client from 2.6.5 to 2.10.2 to resolve CVE-2021-37404

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,10 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-scala_${version.scala.binary}</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -190,6 +194,7 @@
       </exclusions>
     </dependency>
 
+    <!-- BEGIN DIPS override versions -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
@@ -205,6 +210,12 @@
       <artifactId>jackson-module-scala_${version.scala.binary}</artifactId>
       <version>${version.jackson}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <version>2.10.2</version>
+    </dependency>
+    <!-- END DIPS override versions -->
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
And a few other CVEs