### PR TITLE
Add OpenTelemetry runtime metrics being pushed through an OTEL Collector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ RUN chgrp root /etc/passwd && chmod g+rw /etc/passwd
 USER 185
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD java ${JAVA_OPTS} -Dlog4j.configurationFile=classpath:log4j.properties -jar $APP_HOME/jaeger-spark-dependencies-0.0.1-SNAPSHOT.jar
+CMD java ${JAVA_OPTS} -Dlog4j.configurationFile=classpath:log4j.properties -Dotel.service.name=jaeger-spark-dependencies -jar $APP_HOME/jaeger-spark-dependencies-0.0.1-SNAPSHOT.jar

--- a/jaeger-spark-dependencies/pom.xml
+++ b/jaeger-spark-dependencies/pom.xml
@@ -49,6 +49,40 @@
       <artifactId>log4j-layout-template-json</artifactId>
       <version>2.21.0</version>
     </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-otlp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry.instrumentation</groupId>
+      <artifactId>opentelemetry-runtime-telemetry-java8</artifactId>
+      <version>1.31.0-alpha</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-sender-jdk</artifactId>
+      <version>1.31.0-alpha</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -90,6 +124,12 @@
                 </filter>
                 <filter>
                   <artifact>org.apache.logging.log4j:log4j-layout-template-json</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>io.opentelemetry:*</artifact>
                   <includes>
                     <include>**</include>
                   </includes>

--- a/jaeger-spark-dependencies/src/main/java/io/jaegertracing/spark/dependencies/DependenciesSparkJob.java
+++ b/jaeger-spark-dependencies/src/main/java/io/jaegertracing/spark/dependencies/DependenciesSparkJob.java
@@ -15,12 +15,13 @@ package io.jaegertracing.spark.dependencies;
 
 import io.jaegertracing.spark.dependencies.cassandra.CassandraDependenciesJob;
 import io.jaegertracing.spark.dependencies.elastic.ElasticsearchDependenciesJob;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.*;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.Map;
 
 public final class DependenciesSparkJob {
 
@@ -36,6 +37,15 @@ public final class DependenciesSparkJob {
     } else if (System.getenv("DATE") != null) {
       date = parseZonedDateTime(System.getenv("DATE"));
     }
+
+    OpenTelemetrySdk sdk = AutoConfiguredOpenTelemetrySdk.initialize()
+            .getOpenTelemetrySdk();
+    BufferPools.registerObservers(sdk);
+    Classes.registerObservers(sdk);
+    Cpu.registerObservers(sdk);
+    MemoryPools.registerObservers(sdk);
+    Threads.registerObservers(sdk);
+    GarbageCollector.registerObservers(sdk);
 
     run(storage, date);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <version.org.testcontainers>1.18.1</version.org.testcontainers>
     <version.com.squareup.okhttp3-okhttp>3.14.9</version.com.squareup.okhttp3-okhttp>
     <version.org.awaitility-awaitility>4.2.0</version.org.awaitility-awaitility>
+    <version.opentelemetry>1.31.0</version.opentelemetry>
 
     <version.maven-license-plugin>3.0</version.maven-license-plugin>
     <version.maven-compiler-plugin>3.11.0</version.maven-compiler-plugin>
@@ -98,7 +99,13 @@
         <artifactId>jaeger-spark-dependencies-elasticsearch</artifactId>
         <version>${project.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${version.opentelemetry}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-core_${version.scala.binary}</artifactId>
@@ -192,6 +199,47 @@
           <artifactId>jackson-module-scala_${version.scala.binary}</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>${version.opentelemetry}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk</artifactId>
+      <version>${version.opentelemetry}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-metrics</artifactId>
+      <version>${version.opentelemetry}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+      <version>${version.opentelemetry}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
+      <version>${version.opentelemetry}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-otlp</artifactId>
+      <version>${version.opentelemetry}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry.instrumentation</groupId>
+      <artifactId>opentelemetry-runtime-telemetry-java8</artifactId>
+      <version>1.31.0-alpha</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-sender-jdk</artifactId>
+      <version>1.31.0-alpha</version>
     </dependency>
 
     <!-- BEGIN DIPS override versions -->


### PR DESCRIPTION
By using OpenTelemetry instrumentation libraries for Java, the Spark job can push runtime metrics to an OpenTelemetry Collector